### PR TITLE
Add contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at **waskar@philaconvalley.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+### Consequences
+
+1. **Correction** — A private written warning with clarity about the violation.
+2. **Warning** — A warning with consequences for continued behavior.
+3. **Temporary Ban** — Temporary removal from community interaction.
+4. **Permanent Ban** — Permanent removal from the community.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Shopping Debate
+
+Thank you for your interest in contributing! Shopping Debate is a Chrome extension that helps people make thoughtful purchase decisions through AI-powered debates. We welcome contributions of all kinds.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js (v16+)
+- npm
+- Chrome browser
+- An [OpenRouter](https://openrouter.ai/keys) API key (free credits available for new users)
+
+### Local Setup
+
+1. Fork and clone the repository:
+   ```bash
+   git clone https://github.com/<your-username>/shoppingDebateChromeExtension.git
+   cd shoppingDebateChromeExtension
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Set up environment:
+   ```bash
+   cp .env.example .env
+   # Add your OpenRouter API key to .env
+   ```
+
+4. Build and load:
+   ```bash
+   npm run build
+   ```
+   Then load the `dist/` folder as an unpacked extension at `chrome://extensions/`
+
+5. For development with auto-rebuild:
+   ```bash
+   npm run watch
+   ```
+
+## Ways to Contribute
+
+### Code
+- Fix bugs or implement features from the [issues list](https://github.com/philaconvalley/shoppingDebateChromeExtension/issues)
+- Look for `good first issue` labels if you're new
+- Improve checkout detection patterns for more e-commerce sites
+- Add new drama themes or personalities
+
+### Design
+- Propose UI/UX improvements
+- Create new theme designs
+- Improve accessibility
+
+### Documentation
+- Improve setup instructions
+- Add troubleshooting tips
+- Write guides for common customizations
+
+### Testing
+- Test on different e-commerce sites and report results
+- Test across browsers and OS versions
+- Report bugs with detailed reproduction steps
+
+## How to Contribute
+
+1. **Find or create an issue** describing what you want to work on
+2. **Comment on the issue** to let others know you're working on it
+3. **Create a branch** from `main` with a descriptive name
+4. **Make your changes** — keep PRs focused and reasonably small
+5. **Test thoroughly**:
+   - Build with `npm run build`
+   - Test on `test-checkout.html`
+   - Test on at least one real e-commerce site
+   - Check all themes if your change affects UI
+6. **Open a pull request** using the PR template
+
+## Project Structure
+
+```
+src/
+├── background/     # Service worker, API calls, streaming
+├── content/        # Content script, checkout detection, UI
+├── themes/         # Theme configs and styles
+├── shared/         # Constants and storage helpers
+├── options/        # Settings page
+└── popup/          # Extension popup
+```
+
+## Code Style
+
+- Use clear, descriptive variable and function names
+- Comment complex logic, but prefer self-documenting code
+- Keep functions focused — one responsibility per function
+- Test your changes across multiple themes
+
+## Questions?
+
+Open an issue or comment on an existing one. We're happy to help you get started!


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md with local setup instructions, project structure, and contribution workflow
- Add CODE_OF_CONDUCT.md based on Contributor Covenant

## Why
The repo already has issue and PR templates but was missing a contributing guide and code of conduct. New contributors need clear setup steps (npm install, webpack build, Chrome extension loading) and community standards.

## Files Added
- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`

## Test plan
- [ ] Review CONTRIBUTING.md setup steps match current project structure
- [ ] Verify CODE_OF_CONDUCT.md contact info is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)